### PR TITLE
Pom deter

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3,7 +3,7 @@
     <groupId>net.sourceforge.owlapi</groupId>
     <artifactId>telemetry</artifactId>
     <version>1.0.1-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>Telemetry</name>
     <description>A toolkit for recording nested data including CPU times</description>
     <url>https://github.com/matthewhorridge/telemetry</url>
@@ -39,13 +39,13 @@
     <dependencies>
         <dependency>
             <groupId>net.sourceforge.owlapi</groupId>
-            <artifactId>owlapi-distribution</artifactId>
-            <version>3.5.0</version>
+            <artifactId>owlapi-osgidistribution</artifactId>
+            <version>[3.5.0,3.6)</version>
         </dependency>
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
-            <version>1.9.5</version>
+            <version>1.10.17</version>
             <scope>test</scope>
         </dependency>
         <dependency>
@@ -56,8 +56,8 @@
         </dependency>
         <dependency>
             <groupId>junit</groupId>
-            <artifactId>junit-dep</artifactId>
-            <version>4.11</version>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -105,10 +105,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
-                <version>3.1</version>
+                <version>3.2</version>
                 <configuration>
-                    <source>1.6</source>
-                    <target>1.6</target>
+                    <source>1.7</source>
+                    <target>1.7</target>
                     <encoding>UTF-8</encoding>
                 </configuration>
             </plugin>
@@ -143,7 +143,19 @@
                 </executions>
             </plugin>
 
-
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>
+                <extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-SymbolicName>${project.groupId}.${project.artifactId}</Bundle-SymbolicName>
+                        <Bundle-Name>${project.artifactId}</Bundle-Name>
+                        <Export-Package>{local-packages}</Export-Package>
+                    </instructions>
+                </configuration>
+            </plugin>
             <!-- The Surefire Plugin is for error reporting. -->
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/semanticweb/owl/explanation/telemetry/TelemetryXMLWriter.java
+++ b/src/main/java/org/semanticweb/owl/explanation/telemetry/TelemetryXMLWriter.java
@@ -6,7 +6,6 @@ import org.coode.xml.XMLWriter;
 import org.coode.xml.XMLWriterNamespaceManager;
 import org.coode.xml.XMLWriterPreferences;
 import org.semanticweb.owlapi.model.IRI;
-import org.semanticweb.owlapi.vocab.OWL2Datatype;
 
 import java.io.IOException;
 import java.io.Writer;
@@ -109,24 +108,6 @@ public class TelemetryXMLWriter implements XMLWriter {
 
     public void setEncoding(String encoding) {
         this.encoding = encoding;
-    }
-
-    private boolean isValidQName(String name) {
-        if(name == null) {
-            return false;
-        }
-        int colonIndex = name.indexOf(":");
-        boolean valid = false;
-        if (colonIndex == -1) {
-            valid = OWL2Datatype.XSD_NCNAME.getPattern().matcher(name).matches();
-        }
-        else {
-            valid = OWL2Datatype.XSD_NCNAME.getPattern().matcher(name.substring(0, colonIndex - 1)).matches();
-            if (valid) {
-                valid = OWL2Datatype.XSD_NAME.getPattern().matcher(name.substring(colonIndex + 1)).matches();
-            }
-        }
-        return valid;
     }
 
     @Override


### PR DESCRIPTION
Update plugin versions
Change build type to bundle, because er, reasons.

This could _actually_ have been a use case for OSGI, if the API classes were set up in separate bundles from the  providers.
At least the package names  are  distinct from those in owlexplanation, so they can both be loaded at the same time.

Of course,  telemetry  could also be handled JMX MBeans  (which were once used by JBoss to handle service lifecycle for components).

The cycle of lifecycles...
